### PR TITLE
Ability to define multicastInterface

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ module.exports = function (opts) {
     }
 
     if (!updated || !socket.setMulticastInterface) return
-    socket.setMulticastInterface(opts.interface || defaultInterface())
+    socket.setMulticastInterface(opts.multicastInterface || opts.interface || defaultInterface())
   }
 
   return that


### PR DESCRIPTION
In some cases you want to define a different interface for sending the multicast packets out over, even when listening on all.